### PR TITLE
Remove java dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <url>http://github.com/ros-naoqi/nao_meshes2/</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>java</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Remove java dependency.
This dependency doesn't seem to be needed, even when using the installer through GUI mode.